### PR TITLE
fix crash on text without markdown

### DIFF
--- a/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
+++ b/Sources/SwiftyMarkdown/SwiftyLineProcessor.swift
@@ -161,7 +161,7 @@ public class SwiftyLineProcessor {
         }
         let previousLines = lineRules.filter({ $0.changeAppliesTo == .previous })
 
-        guard let lineStyles = getLineStyle(text, currentRules: []) else {
+        guard let lineStyles = getLineStyle(text, currentRules: []), !lineStyles.1.isEmpty  else {
             for element in previousLines {
                 let output = (element.shouldTrim) ? text.trimmingCharacters(in: .whitespaces) : text
                 let charSet = CharacterSet(charactersIn: element.token )

--- a/Tests/SwiftyMarkdownTests/SwiftyMarkdownAttributedStringTests.swift
+++ b/Tests/SwiftyMarkdownTests/SwiftyMarkdownAttributedStringTests.swift
@@ -27,6 +27,8 @@ A more *complicated* example. This one has **it all**. Here is a [link](http://v
 		let md = SwiftyMarkdown(string: string)
 		let attributedString = md.attributedString()
 		
+        XCTAssertNotNil(attributedString)
+        
 		XCTAssertEqual(attributedString.string, "Heading 1\n\nA more complicated example. This one has it all. Here is a link.\n\nHeading 2\n\nHeading 3\n\nThis one is a blockquote")
 		
 		


### PR DESCRIPTION
The app was crashing if the text didn't contain any markdown elements